### PR TITLE
Add tests for `plugin.xml`

### DIFF
--- a/src/sbt-test/sbt-maven/simple/src/main/java/com/github/sbt/maven/simple/SimpleMojo.java
+++ b/src/sbt-test/sbt-maven/simple/src/main/java/com/github/sbt/maven/simple/SimpleMojo.java
@@ -6,14 +6,52 @@ package com.github.sbt.maven.simple;
 
 import static org.apache.maven.plugins.annotations.LifecyclePhase.GENERATE_SOURCES;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 
 @Mojo(name = "simple", defaultPhase = GENERATE_SOURCES, threadSafe = true)
 public class SimpleMojo extends AbstractMojo {
 
+  @Parameter(name = "string", property = "simple.string", required = true, defaultValue = "empty")
+  private String _string;
+
+  @Parameter(property = "simple.set")
+  private Set<File> set = new LinkedHashSet<>();
+
+  @Parameter(property = "simple.directory", required = true, defaultValue = "${project.build.directory}/generated-sources/simple")
+  private File directory;
+
+  @Parameter(property = "simple.map")
+  private Map<String, String> map = new LinkedHashMap<>();
+
+  @Parameter(defaultValue = "${project}", readonly = true, required = true)
+  private MavenProject project;
+
   @Override
   public void execute() {
-    System.out.println("Hi, I'm Simple Mojo!");
+    File file = new File(directory, "simple.txt");
+    try {
+      directory.mkdirs();
+      Files.writeString(file.toPath(), "Hi, I'm Simple Mojo!");
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public String getString() {
+    return _string;
+  }
+
+  public void setString(String string) {
+    this._string = string;
   }
 }

--- a/src/sbt-test/sbt-maven/simple/src/test/scala/com/github/sbt/maven/simple/SimpleMojoSpec.scala
+++ b/src/sbt-test/sbt-maven/simple/src/test/scala/com/github/sbt/maven/simple/SimpleMojoSpec.scala
@@ -41,5 +41,74 @@ class SimpleMojoSpec extends AnyWordSpec with should.Matchers {
     "have correct implementation" in {
       (mojo \\ "implementation").text should be("com.github.sbt.maven.simple.SimpleMojo")
     }
+
+    "have correct thread-safe attribute" in {
+      (mojo \\ "threadSafe").text.toBoolean should be(true)
+    }
+
+    "have correct default phase" in {
+      (mojo \\ "phase").text should be("generate-sources")
+    }
+
+    val params = mojo \\ "parameters" \\ "parameter"
+    val configuration = mojo \\ "configuration"
+
+    "have correct string parameter" in {
+      val param = params.find(n => (n \\ "name").text == "string")
+      val conf = configuration \\ "string"
+      param should not be empty
+      (param.get \\ "type").text should be("java.lang.String")
+      (param.get \\ "required").text.toBoolean should be(true)
+      (param.get \\ "editable").text.toBoolean should be(true)
+      conf \@ "implementation" should be("java.lang.String")
+      conf \@ "default-value" should be("empty")
+      conf.text should be("${simple.string}")
+    }
+
+    "have correct file parameter" in {
+      val param = params.find(n => (n \\ "name").text == "directory")
+      val conf = configuration \\ "directory"
+      param should not be empty
+      (param.get \\ "type").text should be("java.io.File")
+      (param.get \\ "required").text.toBoolean should be(true)
+      (param.get \\ "editable").text.toBoolean should be(true)
+      conf \@ "implementation" should be("java.io.File")
+      conf \@ "default-value" should be("${project.build.directory}/generated-sources/simple")
+      conf.text should be("${simple.directory}")
+    }
+
+    "have correct map parameter" in {
+      val param = params.find(n => (n \\ "name").text == "map")
+      val conf = configuration \\ "map"
+      param should not be empty
+      (param.get \\ "type").text should be("java.util.Map")
+      (param.get \\ "required").text.toBoolean should be(false)
+      (param.get \\ "editable").text.toBoolean should be(true)
+      conf \@ "implementation" should be("java.util.Map")
+      conf.text should be("${simple.map}")
+    }
+
+    "have correct project parameter" in {
+      val param = params.find(n => (n \\ "name").text == "project")
+      val conf = configuration \\ "project"
+      param should not be empty
+      (param.get \\ "type").text should be("org.apache.maven.project.MavenProject")
+      (param.get \\ "required").text.toBoolean should be(true)
+      (param.get \\ "editable").text.toBoolean should be(false)
+      conf \@ "implementation" should be("org.apache.maven.project.MavenProject")
+      conf \@ "default-value" should be("${project}")
+      conf.text should be(empty)
+    }
+
+    "have correct set parameter" in {
+      val param = params.find(n => (n \\ "name").text == "set")
+      val conf = configuration \\ "set"
+      param should not be empty
+      (param.get \\ "type").text should be("java.util.Set")
+      (param.get \\ "required").text.toBoolean should be(false)
+      (param.get \\ "editable").text.toBoolean should be(true)
+      conf \@ "implementation" should be("java.util.Set")
+      conf.text should be("${simple.set}")
+    }
   }
 }


### PR DESCRIPTION
Maven plugin requires plugin.xml descriptor file. More details can be found in the [documentation](https://maven.apache.org/ref/3.9.1/maven-plugin-api/plugin.html). This PR adds plugin.xml file generation feature in SBT.